### PR TITLE
Switch off shared libs. Neater CMakeLists.txt. Const getter member funcs.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,15 +3,19 @@ project(jps3d)
 
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -std=c++11 -Wall -Wno-deprecated-declarations")
 
-IF(NOT CMAKE_BUILD_TYPE)
-  SET(CMAKE_BUILD_TYPE RelWithDebInfo)
-ENDIF()
+option(BUILD_TESTS "Build the tests." OFF)
+# message(STATUS "[jps3d] BUILD_TESTS set to: ${BUILD_TESTS}")
 
-set(BUILD_SHARED_LIBS ON)
+option(INSTALL_PROJECT "Installs the project into standard paths on the system." OFF)
+# message(STATUS "[jps3d] INSTALL_PROJECT set to: ${INSTALL_PROJECT}")
 
-INCLUDE_DIRECTORIES(include/
-                    )
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE RelWithDebInfo)
+endif()
 
+#
+# Create Target Libraries
+#
 add_library(jps_lib src/jps_planner/graph_search.cpp
                     src/jps_planner/jps_planner.cpp)
 target_link_libraries(jps_lib 
@@ -27,36 +31,44 @@ target_include_directories(dmp_lib
                            PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 #
-# Needs a target_link_library path to ark's yaml-cpp which it is not picking up though other ark built packages like Boost and Eigen are being picked up. 
-# Seems to happen after new ark image merge
+# Build Tests
 #
+if(BUILD_TESTS)
 
-# add_executable(create_map test/create_map.cpp)
-# target_link_libraries(create_map
-#                       PRIVATE yaml-cpp)
+  add_executable(create_map test/create_map.cpp)
+  target_link_libraries(create_map
+                        PRIVATE yaml-cpp)
 
-# include(CTest)
+  include(CTest)
 
-# add_executable(test_planner_2d test/test_planner_2d.cpp)
-# target_link_libraries(test_planner_2d jps_lib)
-# add_test(test_planner_2d test_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
+  add_executable(test_planner_2d test/test_planner_2d.cpp)
+  target_link_libraries(test_planner_2d jps_lib)
+  add_test(test_planner_2d test_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
 
-# add_executable(test_planner_3d test/test_planner_3d.cpp)
-# target_link_libraries(test_planner_3d jps_lib)
-# add_test(test_planner_3d test_planner_3d ${CMAKE_SOURCE_DIR}/data/simple3d.yaml)
+  add_executable(test_planner_3d test/test_planner_3d.cpp)
+  target_link_libraries(test_planner_3d jps_lib)
+  add_test(test_planner_3d test_planner_3d ${CMAKE_SOURCE_DIR}/data/simple3d.yaml)
 
-# add_executable(test_distance_map_planner_2d test/test_distance_map_planner_2d.cpp)
-# target_link_libraries(test_distance_map_planner_2d jps_lib dmp_lib)
-# add_test(test_distance_map_planner_2d test_distance_map_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
+  add_executable(test_distance_map_planner_2d test/test_distance_map_planner_2d.cpp)
+  target_link_libraries(test_distance_map_planner_2d jps_lib dmp_lib)
+  add_test(test_distance_map_planner_2d test_distance_map_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
 
+endif()
 
-install(FILES "${PROJECT_NAME}Config.cmake" "${PROJECT_NAME}ConfigVersion.cmake"
-  DESTINATION "share/${PROJECT_NAME}/cmake")
+#
+# Install Project
+#
+if(INSTALL_PROJECT)
 
-install(TARGETS jps_lib dmp_lib
-  RUNTIME DESTINATION bin
-  LIBRARY DESTINATION lib
-  ARCHIVE DESTINATION lib)
+  install(FILES "${PROJECT_NAME}Config.cmake" "${PROJECT_NAME}ConfigVersion.cmake"
+    DESTINATION "share/${PROJECT_NAME}/cmake")
 
-install(DIRECTORY include/jps_basis include/jps_planner include/jps_collision
-        DESTINATION include/)
+  install(TARGETS jps_lib dmp_lib
+    RUNTIME DESTINATION bin
+    LIBRARY DESTINATION lib
+    ARCHIVE DESTINATION lib)
+
+  install(DIRECTORY include/jps_basis include/jps_planner include/jps_collision
+          DESTINATION include/)
+
+endif()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,11 +16,15 @@ add_library(jps_lib src/jps_planner/graph_search.cpp
                     src/jps_planner/jps_planner.cpp)
 target_link_libraries(jps_lib 
                       PRIVATE Eigen3::Eigen Boost::boost)
+target_include_directories(jps_lib
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 add_library(dmp_lib src/distance_map_planner/graph_search.cpp
                     src/distance_map_planner/distance_map_planner.cpp)
 target_link_libraries(dmp_lib 
                       PRIVATE Eigen3::Eigen Boost::boost)
+target_include_directories(dmp_lib
+                           PUBLIC $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>)
 
 #
 # Needs a target_link_library path to ark's yaml-cpp which it is not picking up though other ark built packages like Boost and Eigen are being picked up. 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ ENDIF()
 
 set(BUILD_SHARED_LIBS ON)
 
-INCLUDE_DIRECTORIES(include/)
+INCLUDE_DIRECTORIES(include/
+                    )
 
 add_library(jps_lib src/jps_planner/graph_search.cpp
                     src/jps_planner/jps_planner.cpp)
@@ -21,23 +22,28 @@ add_library(dmp_lib src/distance_map_planner/graph_search.cpp
 target_link_libraries(dmp_lib 
                       PRIVATE Eigen3::Eigen Boost::boost)
 
-add_executable(create_map test/create_map.cpp)
-target_link_libraries(create_map 
-                      PRIVATE yaml-cpp)
+#
+# Needs a target_link_library path to ark's yaml-cpp which it is not picking up though other ark built packages like Boost and Eigen are being picked up. 
+# Seems to happen after new ark image merge
+#
 
-include(CTest)
+# add_executable(create_map test/create_map.cpp)
+# target_link_libraries(create_map
+#                       PRIVATE yaml-cpp)
 
-add_executable(test_planner_2d test/test_planner_2d.cpp)
-target_link_libraries(test_planner_2d jps_lib)
-add_test(test_planner_2d test_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
+# include(CTest)
 
-add_executable(test_planner_3d test/test_planner_3d.cpp)
-target_link_libraries(test_planner_3d jps_lib)
-add_test(test_planner_3d test_planner_3d ${CMAKE_SOURCE_DIR}/data/simple3d.yaml)
+# add_executable(test_planner_2d test/test_planner_2d.cpp)
+# target_link_libraries(test_planner_2d jps_lib)
+# add_test(test_planner_2d test_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
 
-add_executable(test_distance_map_planner_2d test/test_distance_map_planner_2d.cpp)
-target_link_libraries(test_distance_map_planner_2d jps_lib dmp_lib)
-add_test(test_distance_map_planner_2d test_distance_map_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
+# add_executable(test_planner_3d test/test_planner_3d.cpp)
+# target_link_libraries(test_planner_3d jps_lib)
+# add_test(test_planner_3d test_planner_3d ${CMAKE_SOURCE_DIR}/data/simple3d.yaml)
+
+# add_executable(test_distance_map_planner_2d test/test_distance_map_planner_2d.cpp)
+# target_link_libraries(test_distance_map_planner_2d jps_lib dmp_lib)
+# add_test(test_distance_map_planner_2d test_distance_map_planner_2d ${CMAKE_SOURCE_DIR}/data/corridor.yaml)
 
 
 install(FILES "${PROJECT_NAME}Config.cmake" "${PROJECT_NAME}ConfigVersion.cmake"

--- a/include/jps_collision/map_util.h
+++ b/include/jps_collision/map_util.h
@@ -20,13 +20,13 @@ namespace JPS {
       ///Simple constructor
       MapUtil() {}
       ///Get map data
-      Tmap getMap() { return map_; }
+      Tmap getMap() const { return map_; }
       ///Get resolution
-      decimal_t getRes() { return res_; }
+      decimal_t getRes() const { return res_; }
       ///Get dimensions
-      Veci<Dim> getDim() { return dim_; }
+      Veci<Dim> getDim() const { return dim_; }
       ///Get origin
-      Vecf<Dim> getOrigin() { return origin_d_; }
+      Vecf<Dim> getOrigin() const { return origin_d_; }
       ///Get index of a cell
       int getIndex(const Veci<Dim>& pn) {
           return Dim == 2 ? pn(0) + dim_(0) * pn(1) :


### PR DESCRIPTION
- Switch off shared libs option so that targets get built into knight code directly.
- Neater CMakeLists.txt
- Const member funcs.